### PR TITLE
Have process_dir functions pass extra parameters to the read functions

### DIFF
--- a/R/aquatroll.R
+++ b/R/aquatroll.R
@@ -5,6 +5,7 @@
 #' from a Campbell datalogger
 #' @param min_timestamp Minimum timestamp to read, character;
 #' function will skip down in the data until approximately this time
+#' @param quiet Print diagnostic messages? Logical
 #' @description This function uses
 #' \code{\link[readr]{read_csv}} to parse the file into a data frame.
 #' @author Stephanie Pennington
@@ -15,9 +16,9 @@
 #' @examples
 #' fn <- system.file("PNNL_23_WaterLevel600.dat", package = "compasstools")
 #' read_aquatroll600_file(fn)
-read_aquatroll600_file <- function(filename, min_timestamp = NULL) {
+read_aquatroll600_file <- function(filename, min_timestamp = NULL, quiet = FALSE) {
 
-    skip <- calculate_skip(filename, header_rows = 4, min_timestamp)
+    skip <- calculate_skip(filename, header_rows = 4, min_timestamp, quiet = quiet)
     if(skip == -1) return(tibble()) # entire file can be skipped
 
     # Note we have no time zone information, so read the timestamp as character
@@ -42,6 +43,7 @@ read_aquatroll600_file <- function(filename, min_timestamp = NULL) {
 #' from a Campbell datalogger
 #' @param min_timestamp Minimum timestamp to read, character;
 #' function will skip down in the data until approximately this time
+#' @param quiet Print diagnostic messages? Logical
 #' @description This function uses
 #' \code{\link[readr]{read_csv}} to parse the file into a data frame.
 #' @author Stephanie Pennington
@@ -52,9 +54,9 @@ read_aquatroll600_file <- function(filename, min_timestamp = NULL) {
 #' @examples
 #' fn <- system.file("PNNL_21_WaterLevel200.dat", package = "compasstools")
 #' read_aquatroll200_file(fn)
-read_aquatroll200_file <- function(filename, min_timestamp = NULL) {
+read_aquatroll200_file <- function(filename, min_timestamp = NULL, quiet = FALSE) {
 
-    skip <- calculate_skip(filename, header_rows = 4, min_timestamp)
+    skip <- calculate_skip(filename, header_rows = 4, min_timestamp, quiet = quiet)
     if(skip == -1) return(tibble()) # entire file can be skipped
 
     # Note we have no time zone information, so read the timestamp as character
@@ -75,6 +77,8 @@ read_aquatroll200_file <- function(filename, min_timestamp = NULL) {
 #' @param tz Time zone the data are set to
 #' @param dropbox_token Optional Dropbox token
 #' @param progress_bar Optional progress bar to call while reading
+#' @param ... Other parameters to be passed to \code{\link{read_aquatroll200_file}}
+#' or \code{\link{read_aquatroll600_file}}
 #' @description Read a directory of Aqua TROLL 200 and/or 600 files,
 #' either from Dropbox or locally.
 #' @return All Aqua TROLL files in directory, read and concatenated, with some
@@ -87,10 +91,11 @@ read_aquatroll200_file <- function(filename, min_timestamp = NULL) {
 #' @seealso \code{\link{read_aquatroll200_file}} \code{\link{read_aquatroll600_file}}
 #' @export
 #' @author Ben Bond-Lamberty
-process_aquatroll_dir <- function(datadir, tz, dropbox_token = NULL, progress_bar = NULL) {
+process_aquatroll_dir <- function(datadir, tz, dropbox_token = NULL,
+                                  progress_bar = NULL, ...) {
 
     # Set to NULL so that R CMD CHECK doesn't generate notes
-    Instrument<- Pressure<- Pressure600 <- RDO_concen600 <- Salinity <-
+    Instrument <- Pressure<- Pressure600 <- RDO_concen600 <- Salinity <-
         Salinity600 <- Statname <- Temperature <-
         Temperature600 <- Timestamp <- NULL
 
@@ -99,7 +104,8 @@ process_aquatroll_dir <- function(datadir, tz, dropbox_token = NULL, progress_ba
                         pattern = "200\\.dat$",
                         read_function = read_aquatroll200_file,
                         dropbox_token = dropbox_token,
-                        progress_bar = progress_bar)
+                        progress_bar = progress_bar,
+                        ...)
     x200 %>%
         mutate(Instrument = "TROLL200") %>%
         select(Timestamp, Logger_ID = Statname, Temp = Temperature,
@@ -110,7 +116,8 @@ process_aquatroll_dir <- function(datadir, tz, dropbox_token = NULL, progress_ba
                         pattern = "600\\.dat$",
                         read_function = read_aquatroll600_file,
                         dropbox_token = dropbox_token,
-                        progress_bar = progress_bar)
+                        progress_bar = progress_bar,
+                        ...)
     x600 %>%
         mutate(Instrument = "TROLL600") %>%
         select(Timestamp, Temp = Temperature600,

--- a/R/aquatroll.R
+++ b/R/aquatroll.R
@@ -105,6 +105,7 @@ process_aquatroll_dir <- function(datadir, tz, dropbox_token = NULL,
                         read_function = read_aquatroll200_file,
                         dropbox_token = dropbox_token,
                         progress_bar = progress_bar,
+                        # other parameters to be passed to read_aquatroll200_file
                         ...)
     x200 %>%
         mutate(Instrument = "TROLL200") %>%
@@ -117,6 +118,7 @@ process_aquatroll_dir <- function(datadir, tz, dropbox_token = NULL,
                         read_function = read_aquatroll600_file,
                         dropbox_token = dropbox_token,
                         progress_bar = progress_bar,
+                        # other parameters to be passed to read_aquatroll600_file
                         ...)
     x600 %>%
         mutate(Instrument = "TROLL600") %>%

--- a/R/aquatroll.R
+++ b/R/aquatroll.R
@@ -107,11 +107,13 @@ process_aquatroll_dir <- function(datadir, tz, dropbox_token = NULL,
                         progress_bar = progress_bar,
                         # other parameters to be passed to read_aquatroll200_file
                         ...)
-    x200 %>%
-        mutate(Instrument = "TROLL200") %>%
-        select(Timestamp, Logger_ID = Statname, Temp = Temperature,
-               Pressure_psi = Pressure, Salinity, Instrument) ->
-        x200
+    if(nrow(x200)) {
+        x200 %>%
+            mutate(Instrument = "TROLL200") %>%
+            select(Timestamp, Logger_ID = Statname, Temp = Temperature,
+                   Pressure_psi = Pressure, Salinity, Instrument) ->
+            x200
+    }
 
     x600 <- process_dir(datadir,
                         pattern = "600\\.dat$",
@@ -120,12 +122,14 @@ process_aquatroll_dir <- function(datadir, tz, dropbox_token = NULL,
                         progress_bar = progress_bar,
                         # other parameters to be passed to read_aquatroll600_file
                         ...)
-    x600 %>%
-        mutate(Instrument = "TROLL600") %>%
-        select(Timestamp, Temp = Temperature600,
-               Salinity = Salinity600, DO_mgl = RDO_concen600,
-               Pressure_psi = Pressure600, Instrument, Logger_ID = Statname) ->
-        x600
+    if(nrow(x600)) {
+        x600 %>%
+            mutate(Instrument = "TROLL600") %>%
+            select(Timestamp, Temp = Temperature600,
+                   Salinity = Salinity600, DO_mgl = RDO_concen600,
+                   Pressure_psi = Pressure600, Instrument, Logger_ID = Statname) ->
+            x600
+    }
 
     x <- bind_rows(x200, x600)
     if(!nrow(x)) return(x)

--- a/R/dropbox.R
+++ b/R/dropbox.R
@@ -4,12 +4,13 @@
 #' @param filename A Dropbox filename, e.g. returned by \code{drop_dir}
 #' @param token A dropbox token
 #' @param read_function A function to read the downloaded file with
+#' @param ... Other parameters to be passed to \code{read_function}
 #' @description This function downloads and reads (via a caller-supplied
 #' function) a file on Dropbox.
 #' @return A \code{\link[tibble]{tibble}} with the data.
 #' @export
 #' @author Ben Bond-Lamberty
-read_file_dropbox <- function(filename, token, read_function) {
+read_file_dropbox <- function(filename, token, read_function, ...) {
     # We don't want users to need rdrop2 to use this package (i.e. we don't
     # want to put it in DESCRIPTION's Imports:), so check for availability
     if(requireNamespace("rdrop2", quietly = TRUE)) {
@@ -17,7 +18,7 @@ read_file_dropbox <- function(filename, token, read_function) {
         tf <- tempfile()
         rdrop2::drop_download(filename, local_path = tf,
                               dtoken = token, overwrite = TRUE)
-        read_function(tf)
+        read_function(tf, ...)
     } else {
         stop("rdrop2 package is not available")
     }
@@ -31,6 +32,7 @@ read_file_dropbox <- function(filename, token, read_function) {
 #' @param read_function The file-read function to use
 #' @param dropbox_token Optional Dropbox token
 #' @param progress_bar Optional progress bar to call while reading
+#' @param ... Other parameters to be passed to \code{read_function}
 #' @description A general-purpose function to read data files, either from
 #' Dropbox or locally. The function identifies files based on a pattern,
 #' reads data from each file, and binds them together Callers
@@ -44,7 +46,8 @@ read_file_dropbox <- function(filename, token, read_function) {
 #' over \code{\link{rbind}}
 #' @author Ben Bond-Lamberty
 process_dir <- function(datadir, pattern, read_function,
-                        dropbox_token = NULL, progress_bar = NULL) {
+                        dropbox_token = NULL,
+                        progress_bar = NULL, ...) {
 
     local <- is.null(dropbox_token)
 
@@ -68,9 +71,9 @@ process_dir <- function(datadir, pattern, read_function,
         if(!is.null(progress_bar)) progress_bar(1 / total_files)
         # Read file, either locally or from Dropbox
         if(local) {
-            read_function(filename)
+            read_function(filename, ...)
         } else {
-            read_file_dropbox(filename, dropbox_token, read_function)
+            read_file_dropbox(filename, dropbox_token, read_function, ...)
         }
     }
     x <- lapply(s_files, f, read_function, dropbox_token, length(s_files))

--- a/R/sapflow.R
+++ b/R/sapflow.R
@@ -5,6 +5,7 @@
 #' from a Campbell datalogger
 #' @param min_timestamp Minimum timestamp to read, character;
 #' function will skip down in the data until approximately this time
+#' @param quiet Print diagnostic messages? Logical
 #' @description This function reads a local file of raw sapflow data,
 #' extracts the logger number from the header, and uses
 #' \code{\link[readr]{read_csv}} to parse the file into a data frame.

--- a/R/sapflow.R
+++ b/R/sapflow.R
@@ -16,9 +16,9 @@
 #' @examples
 #' fn <- system.file("PNNL_11_sapflow_1min.dat", package = "compasstools")
 #' read_sapflow_file(fn)
-read_sapflow_file <- function(filename, min_timestamp = NULL) {
+read_sapflow_file <- function(filename, min_timestamp = NULL, quiet = FALSE) {
 
-    skip <- calculate_skip(filename, header_rows = 4, min_timestamp)
+    skip <- calculate_skip(filename, header_rows = 4, min_timestamp, quiet = quiet)
     if(skip == -1) return(tibble()) # entire file can be skipped
 
     # Parse line one to extract logger name
@@ -46,6 +46,7 @@ read_sapflow_file <- function(filename, min_timestamp = NULL) {
 #' @param tz Time zone the data are set to
 #' @param dropbox_token Optional Dropbox token
 #' @param progress_bar Optional progress bar to call while reading
+#' @param ... Other parameters to be passed to \code{\link{read_sapflow_file}}
 #' @description Read a directory of sapflow files, either from Dropbox or
 #' locally.
 #' @return All sapflow files in directory, read and concatenated, with some
@@ -58,13 +59,18 @@ read_sapflow_file <- function(filename, min_timestamp = NULL) {
 #' @seealso \code{\link{read_sapflow_file}}
 #' @export
 #' @author Ben Bond-Lamberty
-process_sapflow_dir <- function(datadir, tz, dropbox_token = NULL, progress_bar = NULL) {
+process_sapflow_dir <- function(datadir, tz,
+                                dropbox_token = NULL,
+                                progress_bar = NULL,
+                                ...) {
 
     x <- process_dir(datadir,
                      pattern = "sapflow\\.dat$",
                      read_function = read_sapflow_file,
                      dropbox_token = dropbox_token,
-                     progress_bar = progress_bar)
+                     progress_bar = progress_bar,
+                     # other parameters to be passed to read_sapflow_file
+                     ...)
 
     if(!nrow(x)) return(x)
 

--- a/R/teros.R
+++ b/R/teros.R
@@ -59,6 +59,7 @@ process_teros_dir <- function(datadir, tz, dropbox_token = NULL,
                      read_function = read_teros_file,
                      dropbox_token = dropbox_token,
                      progress_bar = progress_bar,
+                     # other parameters to be passed to read_teros_file
                      ...)
 
     if(!nrow(x)) return(x)

--- a/R/teros.R
+++ b/R/teros.R
@@ -5,6 +5,7 @@
 #' from a Campbell datalogger
 #' @param min_timestamp Minimum timestamp to read, character;
 #' function will skip down in the data until approximately this time
+#' @param quiet Print diagnostic messages? Logical
 #' @description This function uses
 #' \code{\link[readr]{read_csv}} to parse the file into a data frame.
 #' @author Stephanie Pennington
@@ -15,9 +16,9 @@
 #' @examples
 #' fn <- system.file("PNNL_11_Terosdata.dat", package = "compasstools")
 #' read_teros_file(fn)
-read_teros_file <- function(filename, min_timestamp = NULL) {
+read_teros_file <- function(filename, min_timestamp = NULL, quiet = FALSE) {
 
-    skip <- calculate_skip(filename, header_rows = 4, min_timestamp)
+    skip <- calculate_skip(filename, header_rows = 4, min_timestamp, quiet = quiet)
     if(skip == -1) return(tibble()) # entire file can be skipped
 
     # Generate "Teros(1, 1)", "Teros(1, 2)", "Teros(1, 3)", "Teros(2, 1)", etc.
@@ -37,6 +38,7 @@ read_teros_file <- function(filename, min_timestamp = NULL) {
 #' @param tz Time zone the data are set to
 #' @param dropbox_token Optional Dropbox token
 #' @param progress_bar Optional progress bar to call while reading
+#' @param ... Other parameters to be passed to \code{\link{read_teros_file}}
 #' @description Read a directory of TEROS files, either from Dropbox or
 #' locally.
 #' @return All TEROS files in directory, read and concatenated, with some
@@ -49,13 +51,15 @@ read_teros_file <- function(filename, min_timestamp = NULL) {
 #' @seealso \code{\link{read_teros_file}}
 #' @export
 #' @author Ben Bond-Lamberty
-process_teros_dir <- function(datadir, tz, dropbox_token = NULL, progress_bar = NULL) {
+process_teros_dir <- function(datadir, tz, dropbox_token = NULL,
+                              progress_bar = NULL, ...) {
 
     x <- process_dir(datadir,
                      pattern = "Terosdata\\.dat$",
                      read_function = read_teros_file,
                      dropbox_token = dropbox_token,
-                     progress_bar = progress_bar)
+                     progress_bar = progress_bar,
+                     ...)
 
     if(!nrow(x)) return(x)
 

--- a/man/process_aquatroll_dir.Rd
+++ b/man/process_aquatroll_dir.Rd
@@ -4,7 +4,13 @@
 \alias{process_aquatroll_dir}
 \title{Read and process a directory of Aqua TROLL files}
 \usage{
-process_aquatroll_dir(datadir, tz, dropbox_token = NULL, progress_bar = NULL)
+process_aquatroll_dir(
+  datadir,
+  tz,
+  dropbox_token = NULL,
+  progress_bar = NULL,
+  ...
+)
 }
 \arguments{
 \item{datadir}{Directory, either in Dropbox or local}
@@ -14,6 +20,9 @@ process_aquatroll_dir(datadir, tz, dropbox_token = NULL, progress_bar = NULL)
 \item{dropbox_token}{Optional Dropbox token}
 
 \item{progress_bar}{Optional progress bar to call while reading}
+
+\item{...}{Other parameters to be passed to \code{\link{read_aquatroll200_file}}
+or \code{\link{read_aquatroll600_file}}}
 }
 \value{
 All Aqua TROLL files in directory, read and concatenated, with some

--- a/man/process_dir.Rd
+++ b/man/process_dir.Rd
@@ -9,7 +9,8 @@ process_dir(
   pattern,
   read_function,
   dropbox_token = NULL,
-  progress_bar = NULL
+  progress_bar = NULL,
+  ...
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ process_dir(
 \item{dropbox_token}{Optional Dropbox token}
 
 \item{progress_bar}{Optional progress bar to call while reading}
+
+\item{...}{Other parameters to be passed to \code{read_function}}
 }
 \value{
 All data files in directory, read and concatenated

--- a/man/process_sapflow_dir.Rd
+++ b/man/process_sapflow_dir.Rd
@@ -4,7 +4,13 @@
 \alias{process_sapflow_dir}
 \title{Read and process a directory of sapflow files}
 \usage{
-process_sapflow_dir(datadir, tz, dropbox_token = NULL, progress_bar = NULL)
+process_sapflow_dir(
+  datadir,
+  tz,
+  dropbox_token = NULL,
+  progress_bar = NULL,
+  ...
+)
 }
 \arguments{
 \item{datadir}{Directory, either in Dropbox or local}
@@ -14,6 +20,8 @@ process_sapflow_dir(datadir, tz, dropbox_token = NULL, progress_bar = NULL)
 \item{dropbox_token}{Optional Dropbox token}
 
 \item{progress_bar}{Optional progress bar to call while reading}
+
+\item{...}{Other parameters to be passed to \code{\link{read_sapflow_file}}}
 }
 \value{
 All sapflow files in directory, read and concatenated, with some

--- a/man/process_teros_dir.Rd
+++ b/man/process_teros_dir.Rd
@@ -4,7 +4,7 @@
 \alias{process_teros_dir}
 \title{Read and process a directory of TEROS files}
 \usage{
-process_teros_dir(datadir, tz, dropbox_token = NULL, progress_bar = NULL)
+process_teros_dir(datadir, tz, dropbox_token = NULL, progress_bar = NULL, ...)
 }
 \arguments{
 \item{datadir}{Directory, either in Dropbox or local}
@@ -14,6 +14,8 @@ process_teros_dir(datadir, tz, dropbox_token = NULL, progress_bar = NULL)
 \item{dropbox_token}{Optional Dropbox token}
 
 \item{progress_bar}{Optional progress bar to call while reading}
+
+\item{...}{Other parameters to be passed to \code{\link{read_teros_file}}}
 }
 \value{
 All TEROS files in directory, read and concatenated, with some

--- a/man/read_aquatroll200_file.Rd
+++ b/man/read_aquatroll200_file.Rd
@@ -4,7 +4,7 @@
 \alias{read_aquatroll200_file}
 \title{Read a raw Aqua TROLL 200 data file}
 \usage{
-read_aquatroll200_file(filename, min_timestamp = NULL)
+read_aquatroll200_file(filename, min_timestamp = NULL, quiet = FALSE)
 }
 \arguments{
 \item{filename}{Fully-qualified filename of a raw Aqua TROLL 200 dataset
@@ -12,6 +12,8 @@ from a Campbell datalogger}
 
 \item{min_timestamp}{Minimum timestamp to read, character;
 function will skip down in the data until approximately this time}
+
+\item{quiet}{Print diagnostic messages? Logical}
 }
 \value{
 A \code{\link[tibble]{tibble}} with the data.

--- a/man/read_aquatroll600_file.Rd
+++ b/man/read_aquatroll600_file.Rd
@@ -4,7 +4,7 @@
 \alias{read_aquatroll600_file}
 \title{Read a raw Aqua TROLL 600 data file}
 \usage{
-read_aquatroll600_file(filename, min_timestamp = NULL)
+read_aquatroll600_file(filename, min_timestamp = NULL, quiet = FALSE)
 }
 \arguments{
 \item{filename}{Fully-qualified filename of a raw Aqua TROLL 600 dataset
@@ -12,6 +12,8 @@ from a Campbell datalogger}
 
 \item{min_timestamp}{Minimum timestamp to read, character;
 function will skip down in the data until approximately this time}
+
+\item{quiet}{Print diagnostic messages? Logical}
 }
 \value{
 A \code{\link[tibble]{tibble}} with the data.

--- a/man/read_file_dropbox.Rd
+++ b/man/read_file_dropbox.Rd
@@ -4,7 +4,7 @@
 \alias{read_file_dropbox}
 \title{Download and read a data file from Dropbox}
 \usage{
-read_file_dropbox(filename, token, read_function)
+read_file_dropbox(filename, token, read_function, ...)
 }
 \arguments{
 \item{filename}{A Dropbox filename, e.g. returned by \code{drop_dir}}
@@ -12,6 +12,8 @@ read_file_dropbox(filename, token, read_function)
 \item{token}{A dropbox token}
 
 \item{read_function}{A function to read the downloaded file with}
+
+\item{...}{Other parameters to be passed to \code{read_function}}
 }
 \value{
 A \code{\link[tibble]{tibble}} with the data.

--- a/man/read_sapflow_file.Rd
+++ b/man/read_sapflow_file.Rd
@@ -4,7 +4,7 @@
 \alias{read_sapflow_file}
 \title{Read a raw sapflow data file}
 \usage{
-read_sapflow_file(filename, min_timestamp = NULL)
+read_sapflow_file(filename, min_timestamp = NULL, quiet = FALSE)
 }
 \arguments{
 \item{filename}{Fully-qualified filename of a raw sapflow dataset

--- a/man/read_sapflow_file.Rd
+++ b/man/read_sapflow_file.Rd
@@ -12,6 +12,8 @@ from a Campbell datalogger}
 
 \item{min_timestamp}{Minimum timestamp to read, character;
 function will skip down in the data until approximately this time}
+
+\item{quiet}{Print diagnostic messages? Logical}
 }
 \value{
 A \code{\link[tibble]{tibble}} with the data.

--- a/man/read_teros_file.Rd
+++ b/man/read_teros_file.Rd
@@ -4,7 +4,7 @@
 \alias{read_teros_file}
 \title{Read a raw TEROS data file}
 \usage{
-read_teros_file(filename, min_timestamp = NULL)
+read_teros_file(filename, min_timestamp = NULL, quiet = FALSE)
 }
 \arguments{
 \item{filename}{Fully-qualified filename of a raw TEROS dataset
@@ -12,6 +12,8 @@ from a Campbell datalogger}
 
 \item{min_timestamp}{Minimum timestamp to read, character;
 function will skip down in the data until approximately this time}
+
+\item{quiet}{Print diagnostic messages? Logical}
 }
 \value{
 A \code{\link[tibble]{tibble}} with the data.

--- a/tests/testthat/test-aquatroll.R
+++ b/tests/testthat/test-aquatroll.R
@@ -62,6 +62,17 @@ test_that("process_aquatroll_dir works locally", {
     expect_identical(length(unique(x$Logger_ID)), nfiles)
     expect_identical(lubridate::tz(x$Timestamp[1]), "Europe/London") # timezone set correctly
 
+    # Handles min_timestamp
+    max_ts <- max(x$Timestamp)
+    y <- process_aquatroll_dir("test_data/", tz = "EST",
+                           min_timestamp = as.character(max_ts - 1),
+                           quiet = TRUE)
+    expect_gte(min(y$Timestamp), max_ts)
+    y <- process_aquatroll_dir("test_data/", tz = "EST",
+                           min_timestamp = as.character(max_ts + 1),
+                           quiet = TRUE)
+    expect_identical(nrow(y), 0L)
+
     # Handles an empty directory
     x <- process_sapflow_dir(tempdir())
     expect_s3_class(x, "data.frame")

--- a/tests/testthat/test-sapflow.R
+++ b/tests/testthat/test-sapflow.R
@@ -34,6 +34,17 @@ test_that("process_sapflow_dir works locally", {
     expect_identical(length(unique(x$Logger)), nfiles)
     expect_identical(lubridate::tz(x$Timestamp[1]), "Europe/London") # timezone set correctly
 
+    # Handles min_timestamp
+    max_ts <- max(x$Timestamp)
+    y <- process_sapflow_dir("test_data/", tz = "EST",
+                             min_timestamp = as.character(max_ts - 1),
+                             quiet = TRUE)
+    expect_gte(min(y$Timestamp), max_ts)
+    y <- process_sapflow_dir("test_data/", tz = "EST",
+                             min_timestamp = as.character(max_ts + 1),
+                             quiet = TRUE)
+    expect_identical(nrow(y), 0L)
+
     # Handles an empty directory
     x <- process_sapflow_dir(tempdir())
     expect_s3_class(x, "data.frame")

--- a/tests/testthat/test-teros.R
+++ b/tests/testthat/test-teros.R
@@ -34,6 +34,17 @@ test_that("process_teros_dir works locally", {
     expect_identical(length(unique(x$Logger)), nfiles)
     expect_identical(lubridate::tz(x$Timestamp[1]), "Europe/London") # timezone set correctly
 
+    # Handles min_timestamp
+    max_ts <- max(x$Timestamp)
+    y <- process_teros_dir("test_data/", tz = "EST",
+                             min_timestamp = as.character(max_ts - 1),
+                             quiet = TRUE)
+    expect_gte(min(y$Timestamp), max_ts)
+    y <- process_teros_dir("test_data/", tz = "EST",
+                             min_timestamp = as.character(max_ts + 1),
+                             quiet = TRUE)
+    expect_identical(nrow(y), 0L)
+
     # Handles an empty directory
     x <- process_sapflow_dir(tempdir())
     expect_s3_class(x, "data.frame")


### PR DESCRIPTION
Most immediately, this lets us use `min_timestamp` with `process_sapflow_dir()`, etc.

One oddity I don't understand:
```
==> devtools::test()

ℹ Loading compasstools
ℹ Testing compasstools
✓ | F W S  OK | Context
⠏ |        10 | aquatroll                                                  Note: Using an external vector in selections is ambiguous.
i Use `all_of(Timestamp)` instead of `Timestamp` to silence this message.
i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
This message is displayed once per session.
Note: Using an external vector in selections is ambiguous.
i Use `all_of(Temperature600)` instead of `Temperature600` to silence this message.
i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
This message is displayed once per session.
Note: Using an external vector in selections is ambiguous.
i Use `all_of(Salinity600)` instead of `Salinity600` to silence this message.
i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
This message is displayed once per session.
Note: Using an external vector in selections is ambiguous.
i Use `all_of(RDO_concen600)` instead of `RDO_concen600` to silence this message.
i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
This message is displayed once per session.
Note: Using an external vector in selections is ambiguous.
i Use `all_of(Pressure600)` instead of `Pressure600` to silence this message.
i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
This message is displayed once per session.
Note: Using an external vector in selections is ambiguous.
i Use `all_of(Statname)` instead of `Statname` to silence this message.
i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
This message is displayed once per session.
⠸ |        14 | aquatroll                                                  Note: Using an external vector in selections is ambiguous.
i Use `all_of(Temperature)` instead of `Temperature` to silence this message.
i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
This message is displayed once per session.
Note: Using an external vector in selections is ambiguous.
i Use `all_of(Pressure)` instead of `Pressure` to silence this message.
i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
This message is displayed once per session.
Note: Using an external vector in selections is ambiguous.
i Use `all_of(Salinity)` instead of `Salinity` to silence this message.
i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
This message is displayed once per session.
✓ |        17 | aquatroll [0.7s]
✓ |         8 | process_dir                                                
✓ |        12 | sapflow [0.3s]                                             
✓ |        12 | teros [0.3s]                                               
✓ |         7 | utilities [0.2s]                                           

══ Results ════════════════════════════════════════════════════════════════
Duration: 1.5 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 56 ]
```

This is being generated by lines 67 and 71 in `test-aquatroll.R`. 😕 